### PR TITLE
Fix search query bug

### DIFF
--- a/PawNClaw.Backend/PawNClaw.Business/Services/StaffServicecs.cs
+++ b/PawNClaw.Backend/PawNClaw.Business/Services/StaffServicecs.cs
@@ -78,7 +78,8 @@ namespace PawNClaw.Business.Services
 
             if (!string.IsNullOrWhiteSpace(name))
             {
-                values = values.Where(x => name.ToLower().ToLower().Contains(x.Name.ToLower().Trim()));
+                string searchName = name.Trim().ToLower();
+                values = values.Where(x => x.Name.ToLower().Contains(searchName));
             }
             values = status switch
             {


### PR DESCRIPTION
## Summary
- fix staff search query to check staff name contains search string

## Testing
- `dotnet build PawNClaw.Backend/PawNClaw.sln` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683fead6e5908321a4307997947a3717